### PR TITLE
Update eslint-plugin-react to the latest version 🚀

### DIFF
--- a/karma-ci.conf.babel.js
+++ b/karma-ci.conf.babel.js
@@ -35,7 +35,7 @@ const browsersToTest = {
 		base: 'SauceLabs',
 		browserName: 'safari',
 		platform: 'macOS 10.13',
-		version: '11.0',
+		version: '11.1',
 	},
 };
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.3.0",
+    "eslint-plugin-react": "^7.9.1",
     "karma": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",


### PR DESCRIPTION
Upgrade `eslint-plugin-react` to the latest version.

Fix Safari version in SauceLabs CI configuration that is breaking all builds.