### PR TITLE
Update eslint to the latest version 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ script:
 after_script:
   - find artifacts/ -name "*.log"
   - cat artifacts/sauce_connect.log
+cache:
+  directories:
+    - node_modules

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-adapter-react-helper": "^1.2.2",
-    "eslint": "^4.6.1",
+    "eslint": "^5.0.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",


### PR DESCRIPTION
Upgrade `eslint` to the latest version.

Cache npm dependencies in TravisCI.