### PR TITLE
Reduce dependencies and package size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
   "env": {
     "test": {
       "plugins": [
-        ["istanbul", { "exclude": ["**/*.spec.js"] }]
+        ["istanbul", { "exclude": ["**/*.spec.js", "src/helpers/throttle.js"] }]
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/wimpyprogrammer/react-responsive-breakpoints#readme",
   "dependencies": {
-    "lodash.noop": "^3.0.1",
     "lodash.reduce": "^4.6.0",
     "lodash.throttle": "^4.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "url": "https://github.com/wimpyprogrammer/react-responsive-breakpoints/issues"
   },
   "homepage": "https://github.com/wimpyprogrammer/react-responsive-breakpoints#readme",
-  "dependencies": {
-    "lodash.throttle": "^4.1.1"
-  },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/wimpyprogrammer/react-responsive-breakpoints#readme",
   "dependencies": {
-    "lodash.reduce": "^4.6.0",
     "lodash.throttle": "^4.1.1"
   },
   "devDependencies": {

--- a/src/helpers/throttle.js
+++ b/src/helpers/throttle.js
@@ -1,0 +1,101 @@
+// A stripped-down version of lodash throttle from
+// https://github.com/lodash/lodash/blob/0843bd4/lodash.js#L10898-L10914
+
+export default function throttle(func, wait) {
+	let lastArgs;
+	let lastThis;
+	let result;
+	let timerId;
+	let lastCallTime;
+
+	function invokeFunc() {
+		const args = lastArgs;
+		const thisArg = lastThis;
+
+		lastArgs = undefined;
+		lastThis = undefined;
+		result = func.apply(thisArg, args);
+		return result;
+	}
+
+	function trailingEdge() {
+		timerId = undefined;
+
+		// Only invoke if we have `lastArgs` which means `func` has been
+		// debounced at least once.
+		if (lastArgs) {
+			return invokeFunc();
+		}
+		lastArgs = undefined;
+		lastThis = undefined;
+		return result;
+	}
+
+	function shouldInvoke(time) {
+		const timeSinceLastCall = time - lastCallTime;
+
+		// Either this is the first call, activity has stopped and we're at the
+		// trailing edge, the system time has gone backwards and we're treating
+		// it as the trailing edge, or we've hit the `maxWait` limit.
+		return (lastCallTime === undefined
+			|| (timeSinceLastCall >= wait)
+			|| (timeSinceLastCall < 0));
+	}
+
+	function remainingWait(time) {
+		const timeSinceLastCall = time - lastCallTime;
+		const timeWaiting = wait - timeSinceLastCall;
+
+		return timeWaiting;
+	}
+
+	// eslint-disable-next-line consistent-return
+	function timerExpired() {
+		const time = Date.now();
+		if (shouldInvoke(time)) {
+			return trailingEdge();
+		}
+		// Restart the timer.
+		timerId = setTimeout(timerExpired, remainingWait(time));
+	}
+
+	function leadingEdge() {
+		// Reset any `maxWait` timer.
+		// Start the timer for the trailing edge.
+		timerId = setTimeout(timerExpired, wait);
+		// Invoke the leading edge.
+		return invokeFunc();
+	}
+
+	function cancel() {
+		if (timerId !== undefined) {
+			clearTimeout(timerId);
+		}
+		lastArgs = undefined;
+		lastCallTime = undefined;
+		lastThis = undefined;
+		timerId = undefined;
+	}
+
+	function debounced() {
+		const time = Date.now();
+		const isInvoking = shouldInvoke(time);
+
+		// eslint-disable-next-line prefer-rest-params
+		lastArgs = arguments;
+		lastThis = this;
+		lastCallTime = time;
+
+		if (isInvoking) {
+			if (timerId === undefined) {
+				return leadingEdge();
+			}
+		}
+		if (timerId === undefined) {
+			timerId = setTimeout(timerExpired, wait);
+		}
+		return result;
+	}
+	debounced.cancel = cancel;
+	return debounced;
+}

--- a/src/withBreakpointsCustom.js
+++ b/src/withBreakpointsCustom.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 import React, { Component } from 'react';
-import throttle from 'lodash.throttle';
+import throttle from './helpers/throttle';
 
 function noop() {}
 

--- a/src/withBreakpointsCustom.js
+++ b/src/withBreakpointsCustom.js
@@ -1,6 +1,5 @@
 /* eslint-env browser */
 import React, { Component } from 'react';
-import reduce from 'lodash.reduce';
 import throttle from 'lodash.throttle';
 
 function noop() {}
@@ -11,7 +10,9 @@ function isVisible(markerEl) {
 
 export default (options, InnerComponent) => {
 	function calculateBreakpoints() {
-		return reduce(options.breakpoints, (breakpoints, { prop, selector }) => {
+		const breakpointConfig = options.breakpoints || [];
+
+		return breakpointConfig.reduce((breakpoints, { prop, selector }) => {
 			const markerEl = document.querySelector(selector);
 			return { ...breakpoints, [prop]: isVisible(markerEl) };
 		}, {});

--- a/src/withBreakpointsCustom.js
+++ b/src/withBreakpointsCustom.js
@@ -1,8 +1,9 @@
 /* eslint-env browser */
 import React, { Component } from 'react';
-import noop from 'lodash.noop';
 import reduce from 'lodash.reduce';
 import throttle from 'lodash.throttle';
+
+function noop() {}
 
 function isVisible(markerEl) {
 	return !!markerEl && window.getComputedStyle(markerEl).display !== 'none';


### PR DESCRIPTION
Replace dependencies on `lodash.noop`, `lodash.reduce`, and `lodash.throttle` with local or native logic to reduce the package size.

The `throttle.js` helper is lodash's `throttle()` function with only the functionality this package needs.

Closes #86.